### PR TITLE
SA2Variables.h: Rename "Cheats_GiveMaxLives" to "Cheats_GiveAllEmblems"

### DIFF
--- a/SA2ModLoader/include/SA2Variables.h
+++ b/SA2ModLoader/include/SA2Variables.h
@@ -409,7 +409,7 @@ DataPointer(char, AnalyticsEnabled, 0x1A55708);
 DataPointer(int, CheatsEnabled, 0x1A55770);
 DataPointer(int, Cheats_GiveMaxRings, 0x1A55774);
 DataPointer(int, Cheats_GiveAllUpgrades, 0x1A55778);
-DataPointer(int, Cheats_GiveMaxLives, 0x1A5577C);
+DataPointer(int, Cheats_GiveAllEmblems, 0x1A5577C);
 DataPointer(int, P2Start, 0x1A557C4);
 DataPointer(float *, _nj_current_matrix_ptr_, 0x1A557FC);
 DataArray(ObjectMaster *, VibTasks, 0x1A5588C, 4);


### PR DESCRIPTION
The address 0x1a5577c is incorrectly labeled. The cheat does not give you 99 lives. Instead, it sets all the relevant flags to get all the emblems. The address is read at the beginning of the emblem count update function, so the cheat doesn't have any effect until you do something to update the emblem counter (exit a level).