### PR TITLE
Switch 'Extend Vertex Buffer' patch to use the game's `syMalloc` function, and set vertex buf number correctly

### DIFF
--- a/SA2ModLoader/TextureReplacement.cpp
+++ b/SA2ModLoader/TextureReplacement.cpp
@@ -886,19 +886,9 @@ static bool try_texture_pack(const char* filename, NJS_TEXLIST* texlist)
 	if (IsFile(replaced))
 	{
 		ifstream pvmx(replaced, ios::in | ios::binary);
-
-		if ( pvmx::is_pvmx(pvmx) && replace_pvmx(replaced, pvmx, texlist, replacements) )
-		{
-			return true;
-		}
-
-		if ( PAKFile::is_pak(pvmx) && replace_pak(replaced, filename, pvmx, texlist, replacements) )
-		{
-			PrintDebug("Warning! Reading file: ./resource/%sPRS/%s.pak", &BaseResourceFolder, filename);
-			return true;
-		}
-
-		return false;
+		if (pvmx::is_pvmx(pvmx))
+			return replace_pvmx(replaced, pvmx, texlist, replacements);
+		return PAKFile::is_pak(pvmx) && replace_pak(replaced, filename, pvmx, texlist, replacements);
 	}
 
 	// Otherwise it's probably a directory, so try loading it as a texture pack.


### PR DESCRIPTION
When increasing the Ninja vertex buffer size, use the game's `malloc` rather than the Mod Loaders' - this allows other mods to free the memory if needed.

Also set the vertex buffer number correctly.