### PR TITLE
Codeless Config Revamp

### DIFF
--- a/SA2ModLoader/dllmain.cpp
+++ b/SA2ModLoader/dllmain.cpp
@@ -1425,6 +1425,7 @@ void __cdecl InitMods(void)
 							{
 								incDirPath = group->second->getString(dirStr);
 								incDirPathW = group->second->getWString(dirStr);
+								break;
 							}
 						}
 


### PR DESCRIPTION
As per discussion in X-Hax, this makes changes to the codeless config options to make use of config.ini over mod.ini for Include Directories.

In short, the changes are as follows:
- Check mod.ini for "Config" group.
- If present, process Config data (currently only include directories)
- If the IncludeDirCount is over 0, process include directories.
- Check if a config.ini file exists for the mod.
- If one does exist, loop through the include directory count, pull defaults from mod.ini's config, and then loop through all groups in config.ini to see if the corresponding key exists and update the information from config.ini.
- If no config.ini file exists, process only the information in mod.ini.

** This summary was Copy/Pasted from the [SADX counterpart PR](https://github.com/X-Hax/sadx-mod-loader/pull/179)
